### PR TITLE
allow multiple manufacturer specific data

### DIFF
--- a/lib/ble/common/manufacturers/apple/ibeacon.js
+++ b/lib/ble/common/manufacturers/apple/ibeacon.js
@@ -31,9 +31,9 @@ var licenseeNames = {
  * Parse Apple iBeacon manufacturer specific data.
  * @param {Object} advertiserData The object containing all parsed data.
  */
-function process(advertiserData) {
+function process(manufacturerSpecificData) {
   var iBeacon = {};
-  var data = advertiserData.manufacturerSpecificData.data;
+  var data = manufacturerSpecificData.data;
 
   iBeacon.uuid = data.substr(4,32);
   iBeacon.major = data.substr(36,4);
@@ -46,7 +46,7 @@ function process(advertiserData) {
   }
   iBeacon.licenseeName = licenseeName;
 
-  advertiserData.manufacturerSpecificData.iBeacon = iBeacon;
+  manufacturerSpecificData.iBeacon = iBeacon;
 }
 
 

--- a/lib/ble/common/manufacturers/apple/index.js
+++ b/lib/ble/common/manufacturers/apple/index.js
@@ -10,13 +10,13 @@ var ibeacon = require('./ibeacon.js');
  * Parse BLE advertiser manufacturer specific data for Apple.
  * @param {Object} advertiserData The object containing all parsed data.
  */
-function process(advertiserData) {
-  var data = advertiserData.manufacturerSpecificData.data;
+function process(manufacturerSpecificData) {
+  var data = manufacturerSpecificData.data;
   var appleType = data.substr(0,2);
 
   switch(appleType) {
     case '02':
-      ibeacon.process(advertiserData);
+      ibeacon.process(manufacturerSpecificData);
       break;
     case '09':
       // TODO: processAppleTV and/or whatever else uses this

--- a/lib/ble/common/manufacturers/estimote/index.js
+++ b/lib/ble/common/manufacturers/estimote/index.js
@@ -10,14 +10,14 @@ var nearable = require('./nearable.js');
  * Parse BLE advertiser manufacturer specific data for Estimote.
  * @param {Object} advertiserData The object containing all parsed data.
  */
-function process(advertiserData) {
-  var data = advertiserData.manufacturerSpecificData.data;
+function process(manufacturerSpecificData) {
+  var data = manufacturerSpecificData.data;
   var packetType = data.substr(0,2);
 
   switch(packetType) { // Update when we have manufacturer documentation
     case '01':
     default:
-      nearable.process(advertiserData);
+      nearable.process(manufacturerSpecificData);
   }
 }
 

--- a/lib/ble/common/manufacturers/estimote/nearable.js
+++ b/lib/ble/common/manufacturers/estimote/nearable.js
@@ -6,11 +6,11 @@
 
 /**
  * Parse Estimote Nearable manufacturer specific data.
- * @param {Object} advertiserData The object containing all parsed data.
+ * @param {Object} manufacturerSpecificData The object containing all parsed data.
  */
-function process(advertiserData) {
+function process(manufacturerSpecificData) {
   var nearable = {};
-  var data = advertiserData.manufacturerSpecificData.data;
+  var data = manufacturerSpecificData.data;
 
   nearable.id = data.substr(2,16);
   nearable.temperature = toTemperature(data.substr(24,2), data.substr(22,2));
@@ -29,7 +29,7 @@ function process(advertiserData) {
                            data.substr(20,2), data.substr(24,2),
                            data.substr(26,2), data.substr(38,2) ];
 
-  advertiserData.manufacturerSpecificData.nearable = nearable;
+  manufacturerSpecificData.nearable = nearable;
 }
 
 

--- a/lib/ble/common/manufacturers/sticknfind/index.js
+++ b/lib/ble/common/manufacturers/sticknfind/index.js
@@ -9,18 +9,18 @@ var snsmotion = require('./snsmotion.js');
 
 /**
  * Parse BLE advertiser manufacturer specific data for StickNFind.
- * @param {Object} advertiserData The object containing all parsed data.
+ * @param {Object} manufacturerSpecificData The object containing all parsed data.
  */
-function process(advertiserData) {
-  var data = advertiserData.manufacturerSpecificData.data;
+function process(manufacturerSpecificData) {
+  var data = manufacturerSpecificData.data;
   var packetType = data.substr(0,2);
 
   switch(packetType) {
     case '01':
-      snfsingle.process(advertiserData);
+      snfsingle.process(manufacturerSpecificData);
       break;
     case '42':
-      snsmotion.process(advertiserData);
+      snsmotion.process(manufacturerSpecificData);
       break;
     default:
   }

--- a/lib/ble/common/manufacturers/sticknfind/snfsingle.js
+++ b/lib/ble/common/manufacturers/sticknfind/snfsingle.js
@@ -9,11 +9,11 @@ var pdu = require('../../util/pdu.js');
 
 /**
  * Parse StickNFind 'single payload' manufacturer specific data.
- * @param {Object} advertiserData The object containing all parsed data.
+ * @param {Object} manufacturerSpecificData The object containing all parsed data.
  */
-function process(advertiserData) {
+function process(manufacturerSpecificData) {
   var snfBeacon = {};
-  var data = advertiserData.manufacturerSpecificData.data;
+  var data = manufacturerSpecificData.data;
 
   snfBeacon.type = 'V2 Single Payload';
   snfBeacon.id = pdu.reverseBytes(data.substr(2,16));
@@ -28,7 +28,7 @@ function process(advertiserData) {
   snfBeacon.calibration = data.substr(32,2);
   snfBeacon.checksum = data.substr(34,6);
 
-  advertiserData.manufacturerSpecificData.snfBeacon = snfBeacon;
+  manufacturerSpecificData.snfBeacon = snfBeacon;
 }
 
 

--- a/lib/ble/common/manufacturers/sticknfind/snsmotion.js
+++ b/lib/ble/common/manufacturers/sticknfind/snsmotion.js
@@ -9,11 +9,11 @@ var pdu = require('../../util/pdu.js');
 
 /**
  * Parse StickNSense 'motion' manufacturer specific data.
- * @param {Object} advertiserData The object containing all parsed data.
+ * @param {Object} manufacturerSpecificData The object containing all parsed data.
  */
-function process(advertiserData) {
+function process(manufacturerSpecificData) {
   var snfBeacon = {};
-  var data = advertiserData.manufacturerSpecificData.data;
+  var data = manufacturerSpecificData.data;
 
   snfBeacon.type = 'SnS Motion';
   snfBeacon.timestamp = parseInt(pdu.reverseBytes(data.substr(2,8)),16);
@@ -42,7 +42,7 @@ function process(advertiserData) {
   snfBeacon.accelerationZ = parseInt((data.substr(36,2) +
                                       data.substr(40,1)), 16);
 
-  advertiserData.manufacturerSpecificData.snfBeacon = snfBeacon;
+  manufacturerSpecificData.snfBeacon = snfBeacon;
 }
 
 

--- a/lib/ble/data/gap/manufacturerspecificdata.js
+++ b/lib/ble/data/gap/manufacturerspecificdata.js
@@ -28,22 +28,25 @@ function process(payload, cursor, advertiserData) {
 
   var data = payload.substr(cursor+8, pdu.getTagDataLength(payload, cursor)-4);
 
-  advertiserData.manufacturerSpecificData = {
+  if (!advertiserData.manufacturerSpecificData)
+    advertiserData.manufacturerSpecificData = [];
+
+  advertiserData.manufacturerSpecificData.push({
                                  companyName : companyName,
                                  companyIdentifierCode: companyIdentifierCode,
-                                 data: data };
+                                 data: data });
 
   // Interpret the manufacturer specific data, if possible
   // Kindly respect ascending order of company identifier codes 
   switch(companyIdentifierCode) {
     case '004c':
-      apple.process(advertiserData);
+      apple.process(advertiserData.manufacturerSpecificData[advertiserData.manufacturerSpecificData.length-1]);
       break;
     case '00f9':
-      sticknfind.process(advertiserData);
+      sticknfind.process(advertiserData.manufacturerSpecificData[advertiserData.manufacturerSpecificData.length-1]);
       break;
     case '015d':
-      estimote.process(advertiserData);
+      estimote.process(advertiserData.manufacturerSpecificData[advertiserData.manufacturerSpecificData.length-1]);
       break;
     default:
   }


### PR DESCRIPTION
this PR adds support for multiple manufacturer specific data.

The current behaviour if the advertisement has multiple manufacturer specific data is always rewrite with the last one.

This is not desirable in our situation. We have seen beacons with multiple manufacturer specific data.

This PR changes the interface for the manufacturer specific data for it to be a list of objects instead of just the last object. The list of objects contais all the manufacturer specific data.

An example of payload with multiple manufacturer specific data we captured is:

4024689e190491e00201061aff4c000215e2c56db5dffb48d2b060d0f5a71096e000000001c5020a00041653514307ff000000540000