### PR TITLE
Export gatt module and process function for individual invocation

### DIFF
--- a/lib/ble/data/gatt/index.js
+++ b/lib/ble/data/gatt/index.js
@@ -1,0 +1,6 @@
+/**
+ * Copyright reelyActive 2015-2018
+ * We believe in an open Internet of Things
+ */
+var services = require('./services/index.js');
+module.exports.services = services;

--- a/lib/ble/data/index.js
+++ b/lib/ble/data/index.js
@@ -5,6 +5,7 @@
 
 
 var gap = require('./gap/index.js');
+var gatt = require('./gatt/index.js');
 
 
 /**
@@ -20,3 +21,4 @@ function process(payload) {
 
 module.exports.process = process;
 module.exports.gap = gap;
+module.exports.gatt = gatt;


### PR DESCRIPTION
If you're using noble or something like that for recieving BLE advertisements, it's handy to be able to invoke just parts of the processing. That's already the case for most of the gap module, but the gatt module was buried. This makes it a public property so it can be invoked too!