### PR TITLE
Update companyidentifiercodes.js

### DIFF
--- a/lib/ble/common/assignednumbers/companyidentifiercodes.js
+++ b/lib/ble/common/assignednumbers/companyidentifiercodes.js
@@ -316,6 +316,7 @@ var companyNames = {
     "013a": "Tencent Holdings Limited",
     "013b": "Allegion",
     "013c": "Murata Manufacuring Co., Ltd.",
+    "013d": "WirelessWERX",
     "013e": "Nod, Inc.",
     "013f": "B&B Manufacturing Company",
     "0140": "Alpine Electronics (China) Co., Ltd",


### PR DESCRIPTION
While working with advlib  I found missing company in companyidentifiercodes.js. 
I added missing "013d": "WirelessWERX" to companyNames variable. Code and names can be checked at https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/